### PR TITLE
Development/ci

### DIFF
--- a/.tsconfig/tsconfig.node.json
+++ b/.tsconfig/tsconfig.node.json
@@ -21,7 +21,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "baseUrl": "../",
-    "rootDir": "../src",
+    "rootDir": "../",
     "outDir": "../dist",
     "paths": {
       "@/*": ["../src/*"]

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The usual `react-scripts`'s Webpack implementation has been replaced with a simi
 
 ### Motivations
 
-Just something I needed to investigate in isolation, to be used as a guideline for other projects, elsewhere.
+Just something I needed to investigate in isolation, to be used as a guideline for [other projects, elsewhere](https://github.com/nathanjhood/ts-esbuild-react-native-web).
 
 In future, I *might* properly functionize the scripts, improve the Typescript server, *possibly* look at hooking into the React dev overlay for error reporting, "eject"... and more, periodically, if time permits.
 

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -28,7 +28,8 @@ export const createBuildOptions = (options) => {
     // external: ['react', 'react-dom'],
     entryPoints: [
       fileURLToPath(new URL('src/App.tsx', import.meta.url)),
-      fileURLToPath(new URL('src/index.tsx', import.meta.url)),
+      // fileURLToPath(new URL('src/server.tsx', import.meta.url)),
+      fileURLToPath(new URL('src/index.tsx', import.meta.url))
     ],
     // outfile: fileURLToPath(new URL(publicOutFile, import.meta.url)),
     outbase: fileURLToPath(new URL('src', import.meta.url)),

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+// import * as ReactDom from 'react-dom';
+import * as Server from 'react-dom/server';
+
+import logo from './logo.svg';
+import App from './App';
+
+/**
+ * TODO: Point esbuild and index.html at this file and serve with express
+ */
+
+export default Server.renderToString(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)


### PR DESCRIPTION
was unsure what to do with the experimental SSR renderer... decided to mark it as `TODO`  so it can be committed but marked as unused, for now...